### PR TITLE
Fixing second invoke being blocked by current, long running, hub invoke

### DIFF
--- a/src/MorseL.Client/Connection.cs
+++ b/src/MorseL.Client/Connection.cs
@@ -339,7 +339,7 @@ namespace MorseL.Client
                     _logger?.LogError(new EventId(), e, $"Exception thrown during registered callback for {descriptor.MethodName}");
                     Error?.Invoke(new Exception($"Exception thrown during registered callback for {descriptor.MethodName}", e));
                 }
-            });
+            }).ConfigureAwait(false);
 
             return Task.CompletedTask;
         }

--- a/src/MorseL.Client/ConnectionExtensions.cs
+++ b/src/MorseL.Client/ConnectionExtensions.cs
@@ -1,11 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace MorseL.Client
 {
     public static class ConnectionExtensions
     {
+        public static void On(this Connection connection, string methodName, Action onData)
+        {
+            connection.On(methodName, new Type[0], data =>
+            {
+                onData.Invoke();
+            });
+        }
         public static void On<T1>(this Connection connection, string methodName, Action<T1> onData)
         {
             connection.On(methodName, new[] { typeof(T1) }, data =>


### PR DESCRIPTION
Firing (but not forgetting) inbound receive handling. Capturing thrown exceptions to break out of current receive loop and rethrow the exception.