### PR TITLE
Updated MorseL.Redis.Scaleout dependency

### DIFF
--- a/src/MorseL.Scaleout.Redis/MorseL.Scaleout.Redis.csproj
+++ b/src/MorseL.Scaleout.Redis/MorseL.Scaleout.Redis.csproj
@@ -18,7 +18,7 @@
     <ProjectReference Include="..\MorseL\MorseL.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="1.2.6" />
+    <PackageReference Include="StackExchange.Redis.StrongName" Version="1.2.6" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This is to make Scaleout compatible with .Net Core 2.0 (which now includes StackExchange.Redis.StrongName).