### PR TITLE
Issue #21 Perpetual hub exceptions

### DIFF
--- a/src/MorseL.Client/MorseLOptions.cs
+++ b/src/MorseL.Client/MorseLOptions.cs
@@ -43,5 +43,14 @@ namespace MorseL.Client
         /// Defaults to true
         /// </summary>
         public bool RethrowUnobservedExceptions { get; set; } = true;
+
+        /// <summary>
+        /// <para>
+        /// Causes MorseL to throw an exception (handled via <see cref="Connection.Error"/>) when
+        /// a hub reports a method invocation was invalid. This is a critical and
+        /// exceptional error case.
+        /// </para>
+        /// </summary>
+        public bool ThrowOnInvalidRequest { get; set; } = true;
     }
 }

--- a/src/MorseL.Common/Message.cs
+++ b/src/MorseL.Common/Message.cs
@@ -7,7 +7,8 @@ namespace MorseL.Common
         Text = 0,
         ClientMethodInvocation = 1,
         ConnectionEvent = 2,
-        InvocationResult = 3
+        InvocationResult = 3,
+        Error = 4
     }
 
     public class Message

--- a/src/MorseL/HubWebSocketHandler.cs
+++ b/src/MorseL/HubWebSocketHandler.cs
@@ -168,10 +168,9 @@ namespace MorseL
             {
                 invocationDescriptor = Json.DeserializeInvocationDescriptor(serializedInvocationDescriptor, _methods.Values.Select(d => d.MethodExecutor.MethodInfo).ToArray());
             }
-            catch (Exception e)
+            catch (Exception)
             {
-                await HandleUnparseableReceivedInvocationDescriptor(connection, serializedInvocationDescriptor, e);
-                return;
+                // Ignore for now and retry as a missing method
             }
 
             if (invocationDescriptor == null)
@@ -303,11 +302,10 @@ namespace MorseL
 
             _logger?.LogError(new EventId(), exception, $"Invalid message \"{serializedInvocationDescriptor}\" received from {connection.Id}");
 
-            // TODO : Move to a Error type that can be handled specifically
             // Since we don't have an invocation descriptor we can't return an invocation result
             return connection.Channel.SendMessageAsync(new Message()
             {
-                MessageType = MessageType.Text,
+                MessageType = MessageType.Error,
                 Data = $"Invalid message \"{serializedInvocationDescriptor}\""
             });
         }

--- a/test/MorseL.Client.Tests/MorseL.Client.Tests.csproj
+++ b/test/MorseL.Client.Tests/MorseL.Client.Tests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
       <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />

--- a/test/MorseL.Client.WebSockets.Tests/MorseL.Client.WebSockets.Tests.csproj
+++ b/test/MorseL.Client.WebSockets.Tests/MorseL.Client.WebSockets.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
       <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/test/MorseL.Scaleout.Redis.Tests/MorseL.Scaleout.Redis.Tests.csproj
+++ b/test/MorseL.Scaleout.Redis.Tests/MorseL.Scaleout.Redis.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170517-02" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
       <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />

--- a/test/MorseL.Scaleout.Tests/MorseL.Scaleout.Tests.csproj
+++ b/test/MorseL.Scaleout.Tests/MorseL.Scaleout.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170517-02" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
       <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />

--- a/test/MorseL.Shared.Tests/MorseL.Shared.Tests.csproj
+++ b/test/MorseL.Shared.Tests/MorseL.Shared.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />

--- a/test/MorseL.Sockets.Tests/MorseL.Sockets.Test.csproj
+++ b/test/MorseL.Sockets.Tests/MorseL.Sockets.Test.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
       <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/test/MorseL.Tests/MorseL.Tests.csproj
+++ b/test/MorseL.Tests/MorseL.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
       <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>


### PR DESCRIPTION
Middleware was being treated as instance rather than singleton - created
during startup. This meant temporarily stored exception continued to get
rethrown.

- Moved member variable cancellation token and pending exception into
local variables
- Fixed issue where message serialization of invalid arguments was
incorrectly treated as a invalid message rather than missing method hub
- Changed invalid message response to use an Error message type so it
could be properly reported to clients