### PR TITLE
Issue 27 - Invocation result descriptor handling

### DIFF
--- a/src/MorseL.Client.WebSockets/MorseL.Client.WebSockets.csproj
+++ b/src/MorseL.Client.WebSockets/MorseL.Client.WebSockets.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0-pre-02" />
     <PackageReference Include="WebSocket4Net">
-      <Version>0.15.0.8</Version>
+      <Version>0.15.0.9-preview1-20171114</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/src/MorseL.Client.WebSockets/MorseL.Client.WebSockets.csproj
+++ b/src/MorseL.Client.WebSockets/MorseL.Client.WebSockets.csproj
@@ -8,7 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0-pre-02" />
-    <PackageReference Include="WebSocket4Net" Version="0.15.0-beta7" />
+    <PackageReference Include="WebSocket4Net">
+      <Version>0.15.0.8</Version>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/MorseL.Client.WebSockets/WebSocketClient.cs
+++ b/src/MorseL.Client.WebSockets/WebSocketClient.cs
@@ -8,7 +8,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nito.AsyncEx;
 using SuperSocket.ClientEngine;
+using SuperSocket.ClientEngine.Proxy;
 using WebSocket4Net;
+
 
 namespace MorseL.Client.WebSockets
 {
@@ -47,6 +49,8 @@ namespace MorseL.Client.WebSockets
                 Options.ReceiveBufferSize);
             Security = _internalWebSocket.Security;
             securityConfig?.Invoke(Security);
+
+            _internalWebSocket.Proxy = Options.Proxy;
             _internalWebSocket.EnableAutoSendPing = Options.EnableAutoSendPing;
             _internalWebSocket.AutoSendPingInterval = Options.AutoSendPingIntervalSeconds;
 
@@ -303,6 +307,7 @@ namespace MorseL.Client.WebSockets
         public int ReceiveBufferSize { get; set; } = 0;
         public bool EnableAutoSendPing { get; set; } = false;
         public int AutoSendPingIntervalSeconds { get; set; } = 120;
+        public IProxyConnector Proxy { get; set; } = null;
     }
 
     public class WebSocketClientException : Exception

--- a/src/MorseL.Common/InvalidInvocationResultException.cs
+++ b/src/MorseL.Common/InvalidInvocationResultException.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MorseL.Common
+{
+    public class InvalidInvocationResultException : MorseLException
+    {
+        public string InvocationResultDescriptor { get; set; }
+        public string RequestId { get; set; }
+
+        public InvalidInvocationResultException(string invocationResultDescriptor, string requestId) : base("Invalid result descriptor")
+        {
+            InvocationResultDescriptor = invocationResultDescriptor;
+            RequestId = requestId;
+        }
+
+        public InvalidInvocationResultException(string message, string invocationResultDescriptor, string requestId) : base(message)
+        {
+            InvocationResultDescriptor = invocationResultDescriptor;
+            RequestId = requestId;
+        }
+    }
+}

--- a/src/MorseL.Common/LruCache.cs
+++ b/src/MorseL.Common/LruCache.cs
@@ -1,0 +1,82 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace MorseL.Common
+{
+    /**
+     * Based off a modified (mostly c/p) version of
+     * https://stackoverflow.com/a/3719378/110762
+     */
+    public class LruCache<TKey, TValue>
+    {
+        private readonly int _capacity;
+        private readonly Dictionary<TKey, LinkedListNode<LruCacheItem<TKey, TValue>>> _cacheMap = new Dictionary<TKey, LinkedListNode<LruCacheItem<TKey, TValue>>>();
+        private readonly LinkedList<LruCacheItem<TKey, TValue>> _lruList = new LinkedList<LruCacheItem<TKey, TValue>>();
+
+        public LruCache(int capacity)
+        {
+            this._capacity = capacity;
+        }
+
+        public TValue Get(TKey key)
+        {
+            lock (this)
+            {
+                LinkedListNode<LruCacheItem<TKey, TValue>> node;
+                if (_cacheMap.TryGetValue(key, out node))
+                {
+                    TValue value = node.Value.Value;
+                    _lruList.Remove(node);
+                    _lruList.AddLast(node);
+                    return value;
+                }
+                return default(TValue);
+            }
+        }
+
+        public void Add(TKey key, TValue val)
+        {
+            lock (this)
+            {
+                if (_cacheMap.Count >= _capacity)
+                {
+                    RemoveFirst();
+                }
+
+                var cacheItem = new LruCacheItem<TKey, TValue>(key, val);
+                var node = new LinkedListNode<LruCacheItem<TKey, TValue>>(cacheItem);
+                _lruList.AddLast(node);
+                _cacheMap.Add(key, node);
+            }
+        }
+
+        public bool ContainsKey(TKey key)
+        {
+            lock (this)
+            {
+                return _cacheMap.ContainsKey(key);
+            }
+        }
+
+        private void RemoveFirst()
+        {
+            // Remove from LRUPriority
+            var node = _lruList.First;
+            _lruList.RemoveFirst();
+
+            // Remove from cache
+            _cacheMap.Remove(node.Value.Key);
+        }
+    }
+
+    class LruCacheItem<TKey, TValue>
+    {
+        public LruCacheItem(TKey k, TValue v)
+        {
+            Key = k;
+            Value = v;
+        }
+        public TKey Key;
+        public TValue Value;
+    }
+}

--- a/src/MorseL.Common/Serialization/Json.cs
+++ b/src/MorseL.Common/Serialization/Json.cs
@@ -88,6 +88,7 @@ namespace MorseL.Common.Serialization
 
             var id = json.Value<string>("Id");
             var returnType = handlers[id].ResultType;
+            if (!handlers.ContainsKey(id)) throw new InvalidInvocationResultException(jsonString, id);
             var invocationResultDescriptor = new InvocationResultDescriptor
             {
                 Id = id,

--- a/src/MorseL.Sockets/MorseLHttpMiddleware.cs
+++ b/src/MorseL.Sockets/MorseLHttpMiddleware.cs
@@ -95,7 +95,7 @@ namespace MorseL.Sockets
                     await Receive(socket, connection, middleware, cts,
                         async (result, serializedInvocationDescriptor) =>
                         {
-                            if (result.MessageType == WebSocketMessageType.Text)
+                            if (result.MessageType == WebSocketMessageType.Text || result.MessageType == WebSocketMessageType.Binary)
                             {
                                 // We call the connection arg'd method directly to allow for middleware to override the IChannel
                                 var unawaitedTask = Task.Run(async () =>


### PR DESCRIPTION
- Better handle invalid result descriptors
- Referencing internal build of WebSocket4Net until upstream pull-request is accepted
- Added proxy support