### PR TITLE
Add hub handler create/release tests

### DIFF
--- a/src/MorseL/HubWebSocketHandler.cs
+++ b/src/MorseL/HubWebSocketHandler.cs
@@ -23,7 +23,7 @@ namespace MorseL
 {
     public class HubWebSocketHandler<THub> : HubWebSocketHandler<THub, IClientInvoker> where THub : Hub<IClientInvoker>
     {
-        public HubWebSocketHandler(IServiceProvider services, ILoggerFactory loggerFactory, IServiceScopeFactory serviceScopeFactory)
+        public HubWebSocketHandler(IServiceProvider services, ILoggerFactory loggerFactory)
             : base(services, loggerFactory)
         {
         }
@@ -49,7 +49,7 @@ namespace MorseL
             _logger = loggerFactory.CreateLogger<HubWebSocketHandler<THub, TClient>>();
             _serviceScopeFactory = services.GetRequiredService<IServiceScopeFactory>();
             _backplane = services.GetService<IBackplane>();
-            _morselOptions = services.GetService<IOptions<MorseLOptions>>().Value;
+            _morselOptions = services.GetRequiredService<IOptions<MorseLOptions>>().Value;
 
             _authorizeData = typeof(THub).GetTypeInfo().GetCustomAttributes().OfType<IAuthorizeData>().ToArray();
             DiscoverHubMethods();

--- a/test/MorseL.Shared.Tests/MorseL.Shared.Tests.csproj
+++ b/test/MorseL.Shared.Tests/MorseL.Shared.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Moq" Version="4.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/MorseL.Shared.Tests/ServicesMocker.cs
+++ b/test/MorseL.Shared.Tests/ServicesMocker.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using MorseL.Extensions;
+using MorseL.Scaleout;
+using MorseL.Sockets;
+
+namespace MorseL.Shared.Tests
+{
+    public class ServicesMocker
+    {
+        public readonly Mock<IServiceProvider> ServiceProviderMock = new Mock<IServiceProvider>();
+        public readonly Mock<IServiceScopeFactory> ServiceScopeFactoryMock = new Mock<IServiceScopeFactory>();
+        public readonly Mock<IBackplane> BackplaneMock = new Mock<IBackplane>();
+        public readonly Mock<IOptions<MorseLOptions>> MorseLOptionsMock = new Mock<IOptions<MorseLOptions>>();
+        public readonly Mock<ILoggerFactory> LoggerFactoryMock = new Mock<ILoggerFactory>();
+        public readonly Mock<IChannel> ChannelMock = new Mock<IChannel>();
+
+        private readonly Mock<IServiceProvider> HubActivatorMockProvider = new Mock<IServiceProvider>();
+
+        public ServicesMocker()
+        {
+            ServiceProviderMock.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(IServiceScopeFactory))))
+                        .Returns(ServiceScopeFactoryMock.Object);
+
+            var serviceScopeMock = new Mock<IServiceScope>();
+            serviceScopeMock.Setup(m => m.ServiceProvider).Returns(ServiceProviderMock.Object);
+            ServiceScopeFactoryMock.Setup(m => m.CreateScope()).Returns(serviceScopeMock.Object);
+
+            ServiceProviderMock.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(IBackplane)))).Returns(BackplaneMock.Object);
+
+            MorseLOptionsMock.Setup(m => m.Value).Returns(new MorseLOptions());
+            ServiceProviderMock.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(IOptions<MorseLOptions>))))
+                        .Returns(MorseLOptionsMock.Object);
+
+            ServiceProviderMock.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(WebSocketConnectionManager))))
+                        .Returns(new WebSocketConnectionManager());
+
+            ServiceProviderMock.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(ILogger<ClientsDispatcher>))))
+                        .Returns(Mock.Of<ILogger<ClientsDispatcher>>());
+
+            var loggerMock = new Mock<ILogger>();
+            LoggerFactoryMock.Setup(m => m.CreateLogger(It.IsAny<string>())).Returns(loggerMock.Object);
+        }
+
+        public Mock<IHubActivator<THub, IClientInvoker>> RegisterHub<THub>() where THub : Hub<IClientInvoker>, new()
+        {
+            var hubActivatorMock = new Mock<IHubActivator<THub, IClientInvoker>>();
+            hubActivatorMock.Setup(m => m.Create()).Returns(new THub());
+
+            HubActivatorMockProvider.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(THub))))
+                                    .Returns(hubActivatorMock);
+
+            ServiceProviderMock.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(IHubActivator<THub, IClientInvoker>))))
+                        .Returns(hubActivatorMock.Object);
+
+            return hubActivatorMock;
+        }
+
+        public Mock<IHubActivator<THub, IClientInvoker>> GetHubActivator<THub>() where THub : Hub<IClientInvoker>
+        {
+            return HubActivatorMockProvider.Object.GetService(typeof(THub)) as Mock<IHubActivator<THub, IClientInvoker>>;
+        }
+    }
+}

--- a/test/MorseL.Tests/HubWebSocketHandlerTests.cs
+++ b/test/MorseL.Tests/HubWebSocketHandlerTests.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Threading.Tasks;
+using Moq;
+using SocketConnection = MorseL.Sockets.Connection;
+using Xunit;
+using MorseL.Shared.Tests;
+
+namespace MorseL.Tests
+{
+    public class HubWebSocketHandlerTests
+    {
+        public class DefaultHub : Hub<IClientInvoker>
+        { }
+
+        public class FailHub : Hub<IClientInvoker>
+        {
+            public override Task OnConnectedAsync(SocketConnection connection)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override Task OnDisconnectedAsync(Exception exception)
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        private readonly ServicesMocker Mocker = new ServicesMocker();
+
+        public HubWebSocketHandlerTests()
+        {
+            Mocker.RegisterHub<DefaultHub>();
+            Mocker.RegisterHub<FailHub>();
+        }
+
+        [Fact]
+        public void Construction_ShouldNotThrow()
+        {
+            var sut = new HubWebSocketHandler<DefaultHub>(Mocker.ServiceProviderMock.Object, Mocker.LoggerFactoryMock.Object);
+        }
+
+        [Fact]
+        public async Task OnConnectedAsync_ShouldInvokeHubCreateAndRelease()
+        {
+            var sut = new HubWebSocketHandler<DefaultHub>(Mocker.ServiceProviderMock.Object, Mocker.LoggerFactoryMock.Object);
+
+            var connection = new SocketConnection(Guid.NewGuid().ToString(), Mocker.ChannelMock.Object);
+
+            await sut.OnConnectedAsync(connection);
+
+            var defaultHubActivatorMock = Mocker.GetHubActivator<DefaultHub>();
+            defaultHubActivatorMock.Verify(m => m.Create(), Times.Once);
+            defaultHubActivatorMock.Verify(m => m.Release(It.IsAny<DefaultHub>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task OnConnectedAsync_ReleaseShouldBeInvoked_IfHubOnConnectedAsyncThrows()
+        {
+            var sut = new HubWebSocketHandler<FailHub>(Mocker.ServiceProviderMock.Object, Mocker.LoggerFactoryMock.Object);
+
+            var connection = new SocketConnection(Guid.NewGuid().ToString(), Mocker.ChannelMock.Object);
+
+            await Assert.ThrowsAsync<NotSupportedException>(async () =>
+            {
+                await sut.OnConnectedAsync(connection);
+            });
+
+            var failHubActivatorMock = Mocker.GetHubActivator<FailHub>();
+            failHubActivatorMock.Verify(m => m.Release(It.IsAny<FailHub>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task OnDisconnectedAsync_ShouldInvokeHubCreateAndRelease()
+        {
+            var sut = new HubWebSocketHandler<DefaultHub>(Mocker.ServiceProviderMock.Object, Mocker.LoggerFactoryMock.Object);
+
+            var connection = new SocketConnection(Guid.NewGuid().ToString(), Mocker.ChannelMock.Object);
+
+            await sut.OnDisconnectedAsync(connection, null);
+
+            var defaultHubActivatorMock = Mocker.GetHubActivator<DefaultHub>();
+            defaultHubActivatorMock.Verify(m => m.Create(), Times.Once);
+            defaultHubActivatorMock.Verify(m => m.Release(It.IsAny<DefaultHub>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task OnDisconnectedAsync_ShouldInvokeBackplane_OnClientDisconnectedAsync()
+        {
+            var sut = new HubWebSocketHandler<DefaultHub>(Mocker.ServiceProviderMock.Object, Mocker.LoggerFactoryMock.Object);
+
+            var connectionId = Guid.NewGuid().ToString();
+            var connection = new SocketConnection(connectionId, Mocker.ChannelMock.Object);
+
+            await sut.OnDisconnectedAsync(connection, null);
+
+            Mocker.BackplaneMock.Verify(m => m.OnClientDisconnectedAsync(It.Is<string>(v => v == connectionId)), Times.Once);
+        }
+
+        [Fact]
+        public async Task OnDisconnectedAsync_ReleaseShouldBeInvoked_IfHubOnDisconnectedAsyncThrows()
+        {
+            var sut = new HubWebSocketHandler<FailHub>(Mocker.ServiceProviderMock.Object, Mocker.LoggerFactoryMock.Object);
+
+            var connection = new SocketConnection(Guid.NewGuid().ToString(), Mocker.ChannelMock.Object);
+
+            await Assert.ThrowsAsync<NotSupportedException>(async () =>
+            {
+                await sut.OnDisconnectedAsync(connection, null);
+            });
+
+            var failHubActivatorMock = Mocker.GetHubActivator<FailHub>();
+            failHubActivatorMock.Verify(m => m.Release(It.IsAny<FailHub>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task OnDisconnectedAsync_Throws_ShouldInvokeBackplane_OnClientDisconnectedAsync()
+        {
+            var sut = new HubWebSocketHandler<FailHub>(Mocker.ServiceProviderMock.Object, Mocker.LoggerFactoryMock.Object);
+
+            var connectionId = Guid.NewGuid().ToString();
+            var connection = new SocketConnection(connectionId, Mocker.ChannelMock.Object);
+
+            await Assert.ThrowsAsync<NotSupportedException>(async () =>
+            {
+                await sut.OnDisconnectedAsync(connection, null);
+            });
+
+            Mocker.BackplaneMock.Verify(m => m.OnClientDisconnectedAsync(It.Is<string>(v => v == connectionId)), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
Goal is to ensure that Release is always called, even under exception
scenarios.