### PR TITLE
Refactor and add tests for hub method discovery

### DIFF
--- a/src/MorseL/Internal/HubMethodDescriptor.cs
+++ b/src/MorseL/Internal/HubMethodDescriptor.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Microsoft.AspNetCore.Authorization;
+
+namespace MorseL.Internal
+{
+    internal class HubMethodDescriptor
+    {
+        public HubMethodDescriptor(ObjectMethodExecutor methodExecutor)
+        {
+            MethodExecutor = methodExecutor;
+            ParameterTypes = methodExecutor.ActionParameters.Select(p => p.ParameterType).ToArray();
+            AuthorizeData = methodExecutor.MethodInfo.GetCustomAttributes().OfType<AuthorizeAttribute>().ToArray();
+        }
+
+        public ObjectMethodExecutor MethodExecutor { get; }
+
+        public Type[] ParameterTypes { get; }
+
+        public IAuthorizeData[] AuthorizeData { get; }
+    }
+}

--- a/src/MorseL/Internal/HubMethodDiscoverer.cs
+++ b/src/MorseL/Internal/HubMethodDiscoverer.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+
+namespace MorseL.Internal
+{
+    internal class HubMethodDiscoverer<THub, TClient> where THub : Hub<TClient>
+    {
+        internal readonly IDictionary<string, HubMethodDescriptor> _methods = new Dictionary<string, HubMethodDescriptor>(StringComparer.OrdinalIgnoreCase);
+
+        private readonly ILogger<HubMethodDiscoverer<THub, TClient>> _logger;
+
+        public HubMethodDiscoverer(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger<HubMethodDiscoverer<THub, TClient>>();
+
+            DiscoverHubMethods();
+        }
+
+        public MethodInfo[] GetMethodInfos()
+        {
+            return _methods.Values.Select(d => d.MethodExecutor.MethodInfo).ToArray();
+        }
+
+        public bool TryGetHubMethodDescriptor(string methodName, out HubMethodDescriptor hubMethodDescriptor)
+        {
+            return _methods.TryGetValue(methodName, out hubMethodDescriptor);
+        }
+
+        private void DiscoverHubMethods()
+        {
+            var hubType = typeof(THub);
+            foreach (var methodInfo in hubType.GetMethods().Where(IsHubMethod))
+            {
+                var methodName = methodInfo.Name;
+
+                if (_methods.ContainsKey(methodName))
+                {
+                    throw new NotSupportedException($"Duplicate definitions of '{methodName}'. Overloading is not supported.");
+                }
+
+                var executor = ObjectMethodExecutor.Create(methodInfo, hubType.GetTypeInfo());
+                _methods[methodName] = new HubMethodDescriptor(executor);
+
+                if (_logger.IsEnabled(LogLevel.Trace))
+                {
+                    _logger.LogTrace("Hub method '{methodName}' is bound", methodName);
+                }
+            }
+        }
+
+        private static bool IsHubMethod(MethodInfo methodInfo)
+        {
+            if (!methodInfo.IsPublic || methodInfo.IsSpecialName)
+            {
+                return false;
+            }
+
+            var baseDefinition = methodInfo.GetBaseDefinition().DeclaringType;
+            var baseType = baseDefinition.GetTypeInfo().IsGenericType ? baseDefinition.GetGenericTypeDefinition() : baseDefinition;
+            if (typeof(Hub<>) == baseType || typeof(object) == baseType)
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/test/MorseL.Tests/HubMethodDiscovererTests.cs
+++ b/test/MorseL.Tests/HubMethodDiscovererTests.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using MorseL.Internal;
+using MorseL.Shared.Tests;
+using Xunit;
+
+namespace MorseL.Tests
+{
+    public class HubMethodDiscovererTests
+    {
+        private readonly ServicesMocker Mocker = new ServicesMocker();
+
+        public class EmptyHub : Hub<IClientInvoker> { }
+
+        [Fact]
+        public void EmptyHubFindsNoAvailableMethods()
+        {
+            var discoverer = new HubMethodDiscoverer<EmptyHub, IClientInvoker>(
+                Mocker.LoggerFactoryMock.Object);
+            Assert.Empty(discoverer._methods);
+        }
+
+        public class PropertyHub : Hub<IClientInvoker>
+        {
+            public string Foo { get; set; }
+        }
+
+        [Fact]
+        public void HubWithOnlyPropertiesFindsNoAvailableMethods()
+        {
+            var discoverer = new HubMethodDiscoverer<PropertyHub, IClientInvoker>(
+                Mocker.LoggerFactoryMock.Object);
+            Assert.Empty(discoverer._methods);
+        }
+
+        public class AccessibilityHub : Hub<IClientInvoker>
+        {
+            public void PublicMethod() {}
+            protected void ProtectedMethod() {}
+            private void PrivateMethod() {}
+            internal void InternalMethod() {}
+        }
+
+        [Fact]
+        public void ShouldDiscoverPublicMethod()
+        {
+            var discoverer = new HubMethodDiscoverer<AccessibilityHub, IClientInvoker>(
+                Mocker.LoggerFactoryMock.Object);
+            Assert.Contains(discoverer._methods, m => m.Key == "PublicMethod");
+            Assert.Equal(discoverer._methods.Count, 1);
+        }
+
+        [Fact]
+        public void ShouldNotDiscoverProtectedMethod()
+        {
+            var discoverer = new HubMethodDiscoverer<AccessibilityHub, IClientInvoker>(
+                Mocker.LoggerFactoryMock.Object);
+            Assert.DoesNotContain(discoverer._methods, m => m.Key == "ProtectedMethod");
+            Assert.Equal(discoverer._methods.Count, 1);
+        }
+
+        [Fact]
+        public void ShouldNotDiscoverPrivateMethod()
+        {
+            var discoverer = new HubMethodDiscoverer<AccessibilityHub, IClientInvoker>(
+                Mocker.LoggerFactoryMock.Object);
+            Assert.DoesNotContain(discoverer._methods, m => m.Key == "PrivateMethod");
+            Assert.Equal(discoverer._methods.Count, 1);
+        }
+
+        [Fact]
+        public void ShouldNotDiscoverInternalMethod()
+        {
+            var discoverer = new HubMethodDiscoverer<AccessibilityHub, IClientInvoker>(
+                Mocker.LoggerFactoryMock.Object);
+            Assert.DoesNotContain(discoverer._methods, m => m.Key == "InternalMethod");
+            Assert.Equal(discoverer._methods.Count, 1);
+        }
+
+        public class BaseHub : Hub<IClientInvoker>
+        {
+            public void BaseMethod() {}
+        }
+
+        public class SubclassHub : BaseHub 
+        {
+            public void SubclassMethod() {}
+        }
+
+        [Fact]
+        public void InheritingFromAHub_ShouldDiscoverOwnPublicMethod()
+        {
+            var discoverer = new HubMethodDiscoverer<SubclassHub, IClientInvoker>(
+                Mocker.LoggerFactoryMock.Object);
+            Assert.Contains(discoverer._methods, m => m.Key == "SubclassMethod");
+            Assert.Equal(discoverer._methods.Count, 2);
+        }
+
+        [Fact]
+        public void InheritingFromAHub_ShouldDiscoverBaseHubPublicMethod()
+        {
+            var discoverer = new HubMethodDiscoverer<SubclassHub, IClientInvoker>(
+                Mocker.LoggerFactoryMock.Object);
+            Assert.Contains(discoverer._methods, m => m.Key == "BaseMethod");
+            Assert.Equal(discoverer._methods.Count, 2);
+        }
+    }
+}


### PR DESCRIPTION
This branch is based off the other PR.

While I was looking closely at the web socket handler I noticed that there wasn't much testing around the hub method discovery so I looked at adding some.

I opted to factor out the code into a separate internal class so that it could be more readily tested independently (though it still uses the `ServicesMocker` from the other PR for the logger factory).

I did discover, through this testing, that the discovery process picked up a few methods from `object` that I updated the code to ignore using the same method as ignoring `Hub<>` methods.