### PR TITLE
Add test coverage to identify connection leak and resolve it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,8 @@
 language: csharp
-sudo: required
-dist: trusty
 mono: none
-dotnet: 1.0.1
-
-
-addons:
-  apt:
-    sources:
-    - sourceline: 'deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main'
-      key_url: 'https://apt-mo.trafficmanager.net/keys/microsoft.asc'
-    packages:
-    - dotnet-dev-1.0.1
-
+dotnet: 2.1.403
 before_script:
-  - dotnet restore
-  - dotnet restore samples/MorseLSamples.sln
-  
-script:
-  - dotnet build
-  - dotnet build samples/MorseLSamples.sln
-  - dotnet test test/MorseL.Tests/MorseL.Tests.csproj
+ - dotnet restore
+ - dotnet build
+ - dotnet build samples/MorseLSamples.sln
+ - dotnet test

--- a/src/MorseL.Sockets/IWebSocketConnectionManager.cs
+++ b/src/MorseL.Sockets/IWebSocketConnectionManager.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Net.WebSockets;
+using System.Threading.Tasks;
+
+namespace MorseL.Sockets
+{
+    public interface IWebSocketConnectionManager
+    {
+        Connection GetConnection(WebSocket socket);
+        Connection GetConnectionById(string connectionId);
+
+        Connection AddConnection(IChannel channel);
+        Task RemoveConnection(string id);
+    }
+}

--- a/src/MorseL.Sockets/WebSocketConnectionManager.cs
+++ b/src/MorseL.Sockets/WebSocketConnectionManager.cs
@@ -4,18 +4,15 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.WebSockets;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
-using MorseL.Sockets.Middleware;
 
 namespace MorseL.Sockets
 {
     /// <summary>
     /// Singleton instance that manages all Connections.
     /// </summary>
-    public class WebSocketConnectionManager
+    public class WebSocketConnectionManager : IWebSocketConnectionManager
     {
         private readonly ConcurrentDictionary<string, Connection> _connections = new ConcurrentDictionary<string, Connection>();
-
 
         public Connection GetConnectionById(string id)
         {
@@ -51,8 +48,9 @@ namespace MorseL.Sockets
 
         public async Task RemoveConnection(string id)
         {
-            _connections.TryRemove(id, out Connection connection);
+            _connections.TryRemove(id, out var connection);
             await connection.DisposeAsync();
+            connection = null;
         }
 
         private static string CreateConnectionId()

--- a/src/MorseL/ClientsDispatcher.cs
+++ b/src/MorseL/ClientsDispatcher.cs
@@ -13,10 +13,10 @@ namespace MorseL
     public class ClientsDispatcher
     {
         private readonly ILogger _logger;
-        private WebSocketConnectionManager Manager { get; }
+        private IWebSocketConnectionManager Manager { get; }
         private IBackplane Backplane { get; }
 
-        public ClientsDispatcher(WebSocketConnectionManager manager, IBackplane backplane, ILogger<ClientsDispatcher> logger)
+        public ClientsDispatcher(IWebSocketConnectionManager manager, IBackplane backplane, ILogger<ClientsDispatcher> logger)
         {
             Manager = manager;
             Backplane = backplane;

--- a/src/MorseL/Extensions/MorseLExtensions.cs
+++ b/src/MorseL/Extensions/MorseLExtensions.cs
@@ -1,16 +1,11 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq.Expressions;
 using System.Reflection;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using MorseL.Scaleout;
 using MorseL.Sockets;
-using MorseL.Sockets.Middleware;
 
 namespace MorseL.Extensions
 {
@@ -19,7 +14,7 @@ namespace MorseL.Extensions
         public static IMorseLBuilder AddMorseL(this IServiceCollection services, Action<MorseLOptions> options = null)
         {
             services.AddSingleton<IBackplane, DefaultBackplane>();
-            services.AddSingleton<WebSocketConnectionManager>();
+            services.AddSingleton<IWebSocketConnectionManager, WebSocketConnectionManager>();
             services.AddSingleton(typeof(HubWebSocketHandler<>), typeof(HubWebSocketHandler<>));
             services.AddScoped(typeof(IHubActivator<,>), typeof(DefaultHubActivator<,>));
 

--- a/test/MorseL.Shared.Tests/ServicesMocker.cs
+++ b/test/MorseL.Shared.Tests/ServicesMocker.cs
@@ -1,5 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Net.WebSockets;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -18,40 +22,78 @@ namespace MorseL.Shared.Tests
         public readonly Mock<IOptions<MorseLOptions>> MorseLOptionsMock = new Mock<IOptions<MorseLOptions>>();
         public readonly Mock<ILoggerFactory> LoggerFactoryMock = new Mock<ILoggerFactory>();
         public readonly Mock<IChannel> ChannelMock = new Mock<IChannel>();
+        public readonly Mock<IWebSocketConnectionManager> WebSocketConnectionManagerMock = new Mock<IWebSocketConnectionManager>();
 
-        private readonly Mock<IServiceProvider> HubActivatorMockProvider = new Mock<IServiceProvider>();
+        public readonly Mock<HttpContext> HttpContextMock = new Mock<HttpContext>();
+        public readonly Mock<ClaimsPrincipal> UserClaimsPrincipalMock = new Mock<ClaimsPrincipal>();
+        public readonly Mock<WebSocketManager> WebSocketManagerMock = new Mock<WebSocketManager>();
+        public readonly Mock<WebSocket> WebSocketMock = new Mock<WebSocket>();
+
+        public readonly string ConnectionId = Guid.NewGuid().ToString();
+
+        private readonly Mock<IServiceProvider> _hubActivatorProviderMock = new Mock<IServiceProvider>();
 
         public ServicesMocker()
         {
-            ServiceProviderMock.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(IServiceScopeFactory))))
-                        .Returns(ServiceScopeFactoryMock.Object);
+            RegisterService(ServiceProviderMock);
+            RegisterService(ServiceScopeFactoryMock);
+            RegisterService(LoggerFactoryMock);
+            RegisterService(WebSocketConnectionManagerMock);
 
             var serviceScopeMock = new Mock<IServiceScope>();
             serviceScopeMock.Setup(m => m.ServiceProvider).Returns(ServiceProviderMock.Object);
             ServiceScopeFactoryMock.Setup(m => m.CreateScope()).Returns(serviceScopeMock.Object);
 
-            ServiceProviderMock.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(IBackplane)))).Returns(BackplaneMock.Object);
+            RegisterService(BackplaneMock);
 
             MorseLOptionsMock.Setup(m => m.Value).Returns(new MorseLOptions());
-            ServiceProviderMock.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(IOptions<MorseLOptions>))))
-                        .Returns(MorseLOptionsMock.Object);
+            RegisterService(MorseLOptionsMock);
 
-            ServiceProviderMock.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(WebSocketConnectionManager))))
-                        .Returns(new WebSocketConnectionManager());
+            RegisterService<ILogger<ClientsDispatcher>>();
 
-            ServiceProviderMock.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(ILogger<ClientsDispatcher>))))
-                        .Returns(Mock.Of<ILogger<ClientsDispatcher>>());
+            var connection = new Connection(ConnectionId, ChannelMock.Object);
+
+            WebSocketConnectionManagerMock.Setup(m => m.AddConnection(It.IsAny<IChannel>())).Returns(connection);
+            WebSocketConnectionManagerMock.Setup(m => m.GetConnectionById(It.Is<string>(s => s == ConnectionId)))
+                .Returns(connection);
+            WebSocketConnectionManagerMock.Setup(m => m.GetConnection(It.Is<WebSocket>(ws => ws == WebSocketMock.Object)))
+                .Returns(connection);
 
             var loggerMock = new Mock<ILogger>();
             LoggerFactoryMock.Setup(m => m.CreateLogger(It.IsAny<string>())).Returns(loggerMock.Object);
+
+            HttpContextMock.Setup(m => m.WebSockets).Returns(WebSocketManagerMock.Object);
+            HttpContextMock.Setup(m => m.RequestServices).Returns(ServiceProviderMock.Object);
+            HttpContextMock.Setup(m => m.User).Returns(UserClaimsPrincipalMock.Object);
+
+            WebSocketMock.Setup(m => m.State).Returns(WebSocketState.None);
+            WebSocketMock.Setup(m => m.ReceiveAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new WebSocketReceiveResult(0, WebSocketMessageType.Close, true)));
+
+            WebSocketManagerMock.Setup(m => m.IsWebSocketRequest).Returns(true);
+            WebSocketManagerMock.Setup(m => m.AcceptWebSocketAsync()).Returns(Task.FromResult(WebSocketMock.Object));
         }
 
-        public Mock<IHubActivator<THub, IClientInvoker>> RegisterHub<THub>() where THub : Hub<IClientInvoker>, new()
+        public Mock<TService> RegisterService<TService>(DefaultValue defaultValue = DefaultValue.Empty) where TService : class
+        {
+            var mock = new Mock<TService> { DefaultValue = defaultValue };
+
+            RegisterService(mock);
+
+            return mock;
+        }
+
+        public void RegisterService<TService>(Mock<TService> mock) where TService : class
+        {
+            ServiceProviderMock.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(TService)))).Returns(mock.Object);
+        }
+
+        public Mock<IHubActivator<THub, IClientInvoker>> RegisterHub<THub>(THub hub = null) where THub : Hub<IClientInvoker>, new()
         {
             var hubActivatorMock = new Mock<IHubActivator<THub, IClientInvoker>>();
-            hubActivatorMock.Setup(m => m.Create()).Returns(new THub());
+            hubActivatorMock.Setup(m => m.Create()).Returns(hub ?? new THub());
 
-            HubActivatorMockProvider.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(THub))))
+            _hubActivatorProviderMock.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(THub))))
                                     .Returns(hubActivatorMock);
 
             ServiceProviderMock.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(IHubActivator<THub, IClientInvoker>))))
@@ -62,7 +104,7 @@ namespace MorseL.Shared.Tests
 
         public Mock<IHubActivator<THub, IClientInvoker>> GetHubActivator<THub>() where THub : Hub<IClientInvoker>
         {
-            return HubActivatorMockProvider.Object.GetService(typeof(THub)) as Mock<IHubActivator<THub, IClientInvoker>>;
+            return _hubActivatorProviderMock.Object.GetService(typeof(THub)) as Mock<IHubActivator<THub, IClientInvoker>>;
         }
     }
 }

--- a/test/MorseL.Sockets.Tests/MorseLHttpMiddlewareTests.cs
+++ b/test/MorseL.Sockets.Tests/MorseLHttpMiddlewareTests.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using MorseL.Shared.Tests;
+using MorseLIMiddleware = MorseL.Sockets.Middleware.IMiddleware;
+using Xunit;
+using System.Net.WebSockets;
+using System.Threading;
+
+namespace MorseL.Sockets.Test
+{
+    public class MorseLHttpMiddlewareTests
+    {
+        private readonly ServicesMocker Mocker = new ServicesMocker();
+
+        public interface IMockRequestDelegate
+        {
+            Task Next(HttpContext context);
+        }
+        private readonly Mock<IMockRequestDelegate> RequestDelegateMock = new Mock<IMockRequestDelegate>();
+
+        public class MiddlewareTestHub : Hub<IClientInvoker> 
+        {
+            public Exception DisconnectedException { get; private set; }
+
+            public override Task OnDisconnectedAsync(Exception exception)
+            {
+                DisconnectedException = exception;
+                return base.OnDisconnectedAsync(exception);
+            }
+        }
+        private readonly MiddlewareTestHub Hub = new MiddlewareTestHub();
+
+        public MorseLHttpMiddlewareTests()
+        {
+            Mocker.RegisterService<ILogger<MorseLHttpMiddleware>>();
+            Mocker.RegisterService<IEnumerable<MorseLIMiddleware>>(DefaultValue.Mock);
+
+            Mocker.RegisterHub<MiddlewareTestHub>(Hub);
+
+            RequestDelegateMock.Setup(m => m.Next(It.IsAny<HttpContext>())).Returns(Task.CompletedTask);
+        }
+
+        private MorseLHttpMiddleware CreateMorseLHttpMiddleware(CancellationTokenSource cts = default(CancellationTokenSource))
+        {
+            return new MorseLHttpMiddleware(
+                Mocker.ServiceProviderMock.Object.GetRequiredService<ILogger<MorseLHttpMiddleware>>(),
+                RequestDelegateMock.Object.Next,
+                typeof(HubWebSocketHandler<MiddlewareTestHub>),
+                cts);
+        }
+
+        [Fact]
+        public async Task NonWebSocketRequest_InvokesNextRequestDelegate()
+        {
+            var sut = CreateMorseLHttpMiddleware();
+
+            Mocker.WebSocketManagerMock.Setup(m => m.IsWebSocketRequest).Returns(false);
+
+            await sut.Invoke(Mocker.HttpContextMock.Object);
+
+            RequestDelegateMock.Verify(m => m.Next(It.Is<HttpContext>(hc => hc == Mocker.HttpContextMock.Object)), Times.Once);
+        }
+
+        [Fact]
+        public async Task WebSocketRequest_DoesNotInvokeNextRequestDelegate()
+        {
+            var sut = CreateMorseLHttpMiddleware();
+
+            await sut.Invoke(Mocker.HttpContextMock.Object);
+
+            RequestDelegateMock.Verify(m => m.Next(It.IsAny<HttpContext>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task WebSocketRequest_ShouldBeAddedToConnectionManager()
+        {
+            var sut = CreateMorseLHttpMiddleware();
+
+            await sut.Invoke(Mocker.HttpContextMock.Object);
+
+            Mocker.WebSocketConnectionManagerMock.Verify(m => m.AddConnection(It.IsAny<IChannel>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task WebSocketRequest_ShouldBeRemovedFromConnectionManager_IfSocketIsNotOpen()
+        {
+            Mocker.WebSocketMock.Setup(m => m.State).Returns(WebSocketState.None);
+
+            var sut = CreateMorseLHttpMiddleware();
+
+            await sut.Invoke(Mocker.HttpContextMock.Object);
+
+            Mocker.WebSocketConnectionManagerMock
+                .Verify(m => m.RemoveConnection(It.Is<string>(s => s == Mocker.ConnectionId)), Times.Once);
+        }
+
+        [Fact]
+        public async Task WebSocketRequest_ShouldBeRemovedFromConnectionManager_IfCancellationIsRequested()
+        {
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var sut = CreateMorseLHttpMiddleware(cts);
+
+            await sut.Invoke(Mocker.HttpContextMock.Object);
+
+            Mocker.WebSocketConnectionManagerMock
+                .Verify(m => m.RemoveConnection(It.Is<string>(s => s == Mocker.ConnectionId)), Times.Once);
+        }
+
+        [Fact]
+        public async Task WebSocketRequest_ShouldBeRemovedFromConnectionManager_IfExceptionThrownInReceiveLoop()
+        {
+            Mocker.WebSocketMock.Setup(m => m.State).Returns(WebSocketState.Open);
+            Mocker.WebSocketMock.Setup(m => m.ReceiveAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<CancellationToken>()))
+                .Throws<Exception>();
+
+            var sut = CreateMorseLHttpMiddleware();
+
+            await sut.Invoke(Mocker.HttpContextMock.Object);
+
+            Mocker.WebSocketConnectionManagerMock
+                .Verify(m => m.RemoveConnection(It.Is<string>(s => s == Mocker.ConnectionId)), Times.Once);
+        }
+
+        [Fact]
+        public async Task WebSocketRequest_ShouldBeRemovedFromConnectionManager_IfCloseMessageIsReceived()
+        {
+            Mocker.WebSocketMock.Setup(m => m.State).Returns(WebSocketState.Open);
+
+            var sut = CreateMorseLHttpMiddleware();
+
+            // Fire and forget since this is essentially just an infinite loop
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+            sut.Invoke(Mocker.HttpContextMock.Object);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+
+            // We eventually need to transition the socket to closed so as to simulate
+            // a proper close of the web socket.
+            await Task.Delay(TimeSpan.FromMilliseconds(5));
+            Mocker.WebSocketMock.Setup(m => m.State).Returns(WebSocketState.Closed);
+
+            Mocker.WebSocketConnectionManagerMock
+                .Verify(m => m.RemoveConnection(It.Is<string>(s => s == Mocker.ConnectionId)), Times.AtLeastOnce); 
+        }
+
+        [Fact]
+        public async Task WebSocketRequest_ExceptionThrownInReceiveLoop_ShouldPassExceptionToOnDisconnected()
+        {
+            var exception = new Exception("Expected Exception");
+            Mocker.WebSocketMock.Setup(m => m.State).Throws(exception);
+
+            var sut = CreateMorseLHttpMiddleware();
+
+            await sut.Invoke(Mocker.HttpContextMock.Object);
+
+            Assert.Same(exception, Hub.DisconnectedException);
+        }
+    }
+}


### PR DESCRIPTION
This includes some refactoring - a couple renames, the addition of `IWebSocketConnectionManager` so the tests could use verifiable mocks etc.

I was able to find a couple failing test scenarios related to the connection _not_ being removed from the connection manager (abnormal but non-exceptional socket termination scenarios) which seems to have manifested as a leak (which included a fair bit of the `HttpContext` , claims,etc).

It includes an update for the travis file just to get a little bit of CI goodness in here for now. I have a more complete one (with a full build matrix!) brewing in another branch.