### PR TITLE
Polish recently added tests

### DIFF
--- a/src/MorseL.Sockets/MorseLHttpMiddleware.cs
+++ b/src/MorseL.Sockets/MorseLHttpMiddleware.cs
@@ -51,17 +51,14 @@ namespace MorseL.Sockets
     {
         private readonly ILogger _logger;
         private readonly RequestDelegate _next;
-        private readonly CancellationTokenSource _cts;
 
         private Type HandlerType { get; }
 
         public MorseLHttpMiddleware(
-            ILogger<MorseLHttpMiddleware> logger, RequestDelegate next, 
-            Type handlerType, CancellationTokenSource cts = default(CancellationTokenSource))
+            ILogger<MorseLHttpMiddleware> logger, RequestDelegate next, Type handlerType)
         {
             _logger = logger;
             _next = next;
-            _cts = cts ?? new CancellationTokenSource();
             HandlerType = handlerType;
         }
 
@@ -73,33 +70,32 @@ namespace MorseL.Sockets
                 return;
             }
 
-            WebSocketHandler handler = null;
-            try
+            var cts = new CancellationTokenSource();
+            Exception pendingException = null;
+
+            using (var serviceScope = context.RequestServices.CreateScope())
             {
-                Exception pendingException = null;
-                using (var serviceScope = context.RequestServices.CreateScope())
+                var services = serviceScope.ServiceProvider;
+                var middleware = services.GetServices<IMiddleware>().ToList();
+
+                var handler = ActivatorUtilities.CreateInstance(services, HandlerType) as WebSocketHandler;
+                if (handler == null)
                 {
-                    var services = serviceScope.ServiceProvider;
-                    var middleware = services.GetServices<IMiddleware>().ToList();
+                    throw new Exception("Invalid handler type specified. Must be a Hub.");
+                }
 
-                    handler = ActivatorUtilities.CreateInstance(services, HandlerType) as WebSocketHandler;
-                    if (handler == null)
-                    {
-                        throw new Exception("Invalid handler type specified. Must be a Hub.");
-                    }
+                var socket = await context.WebSockets.AcceptWebSocketAsync().ConfigureAwait(false);
 
-                    var socket = await context.WebSockets.AcceptWebSocketAsync().ConfigureAwait(false);
+                try
+                {
+                    // TODO : Consider/Decide on pulling web socket manager outside of handler
+                    var connection = await handler.OnConnected(socket, context).ConfigureAwait(false);
 
-                    try
-                    {
-                        // TODO : Consider/Decide on pulling web socket manager outside of handler
-                        var connection = await handler.OnConnected(socket, context).ConfigureAwait(false);
-
-                        await Receive(socket, connection, middleware, _cts,
-                            async (result, serializedInvocationDescriptor) =>
+                    await Receive(socket, connection, middleware, cts,
+                        async (result, serializedInvocationDescriptor) =>
+                        {
+                            if (result.MessageType == WebSocketMessageType.Text || result.MessageType == WebSocketMessageType.Binary)
                             {
-                                if (result.MessageType == WebSocketMessageType.Text || result.MessageType == WebSocketMessageType.Binary)
-                                {
                                 // We call the connection arg'd method directly to allow for middleware to override the IChannel
                                 var unawaitedTask = Task.Run(async () =>
                                     {
@@ -109,59 +105,54 @@ namespace MorseL.Sockets
                                         }
                                         catch (Exception exception)
                                         {
-                                        // An exception here means it was thrown during message handling (not in the Hub method itself)
-                                        // This is a big issue (likely message serialization) and can't be "saved"
-                                        // We'll store the exception and rethrow after the receive loop is brought down
-                                        pendingException = exception;
-                                            _cts.Cancel();
+                                            // An exception here means it was thrown during message handling (not in the Hub method itself)
+                                            // This is a big issue (likely message serialization) and can't be "saved"
+                                            // We'll store the exception and rethrow after the receive loop is brought down
+                                            pendingException = exception;
+                                            cts.Cancel();
                                         }
-
                                     }).ConfigureAwait(false);
-                                }
-                                else if (result.MessageType == WebSocketMessageType.Close)
-                                {
-                                    await handler.OnDisconnected(socket, null);
-                                }
-                            }).ConfigureAwait(false);
+                            }
+                            else if (result.MessageType == WebSocketMessageType.Close)
+                            {
+                                await handler.OnDisconnected(socket, null);
+                            }
+                        }).ConfigureAwait(false);
 
-                        // Rethrow any exception thrown during message processing that broke our receive loop
-                        if (pendingException != null)
-                        {
-                            ExceptionDispatchInfo.Capture(pendingException).Throw();
-                        }
-                    }
-                    catch (Exception exception)
+                    // Rethrow any exception thrown during message processing that broke our receive loop
+                    if (pendingException != null)
                     {
-                        if (pendingException == null || pendingException != exception)
-                        {
-                            pendingException = exception;
-                        }
-
-                        _logger?.LogError(new EventId(), exception, "Exception thrown during receive loop");
-
-                        if (exception is MorseLException)
-                        {
-                            // For now, rethrow morsel exceptions
-                            throw;
-                        }
-                    }
-                    finally
-                    {
-                        try
-                        {
-                            await handler.OnDisconnected(socket, pendingException);
-                        }
-                        catch (WebSocketException webSocketException)
-                        {
-                            _logger?.LogWarning(new EventId(), webSocketException, "Exception attempting to close socket");
-                        }
+                        ExceptionDispatchInfo.Capture(pendingException).Throw();
                     }
                 }
-            }
-            finally
-            {
-                handler = null;
-                _cts.Dispose();
+                catch (Exception exception)
+                {
+                    if (pendingException == null || pendingException != exception)
+                    {
+                        pendingException = exception;
+                    }
+
+                    _logger?.LogError(new EventId(), exception, "Exception thrown during receive loop");
+
+                    if (exception is MorseLException)
+                    {
+                        // For now, rethrow morsel exceptions
+                        throw;
+                    }
+                }
+                finally
+                {
+                    try
+                    {
+                        await handler.OnDisconnected(socket, pendingException);
+                    }
+                    catch (WebSocketException webSocketException)
+                    {
+                        _logger?.LogWarning(new EventId(), webSocketException, "Exception attempting to close socket");
+                    }
+
+                    cts.Dispose();
+                }
             }
         }
 

--- a/src/MorseL/HubWebSocketHandler.cs
+++ b/src/MorseL/HubWebSocketHandler.cs
@@ -135,7 +135,7 @@ namespace MorseL
             InvocationDescriptor invocationDescriptor = null;
             try
             {
-                invocationDescriptor = Json.DeserializeInvocationDescriptor(serializedInvocationDescriptor, _hubMethodDiscoverer.GetMethodInfos());
+                invocationDescriptor = Json.DeserializeInvocationDescriptor(serializedInvocationDescriptor, _hubMethodDiscoverer.GetAllMethodInfo());
             }
             catch (Exception)
             {

--- a/src/MorseL/Internal/HubMethodDiscoverer.cs
+++ b/src/MorseL/Internal/HubMethodDiscoverer.cs
@@ -19,7 +19,7 @@ namespace MorseL.Internal
             DiscoverHubMethods();
         }
 
-        public MethodInfo[] GetMethodInfos()
+        public MethodInfo[] GetAllMethodInfo()
         {
             return _methods.Values.Select(d => d.MethodExecutor.MethodInfo).ToArray();
         }

--- a/test/MorseL.Shared.Tests/ServicesMocker.cs
+++ b/test/MorseL.Shared.Tests/ServicesMocker.cs
@@ -54,10 +54,8 @@ namespace MorseL.Shared.Tests
             var connection = new Connection(ConnectionId, ChannelMock.Object);
 
             WebSocketConnectionManagerMock.Setup(m => m.AddConnection(It.IsAny<IChannel>())).Returns(connection);
-            WebSocketConnectionManagerMock.Setup(m => m.GetConnectionById(It.Is<string>(s => s == ConnectionId)))
-                .Returns(connection);
-            WebSocketConnectionManagerMock.Setup(m => m.GetConnection(It.Is<WebSocket>(ws => ws == WebSocketMock.Object)))
-                .Returns(connection);
+            WebSocketConnectionManagerMock.Setup(m => m.GetConnectionById(ConnectionId)).Returns(connection);
+            WebSocketConnectionManagerMock.Setup(m => m.GetConnection(WebSocketMock.Object)).Returns(connection);
 
             var loggerMock = new Mock<ILogger>();
             LoggerFactoryMock.Setup(m => m.CreateLogger(It.IsAny<string>())).Returns(loggerMock.Object);
@@ -85,7 +83,7 @@ namespace MorseL.Shared.Tests
 
         public void RegisterService<TService>(Mock<TService> mock) where TService : class
         {
-            ServiceProviderMock.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(TService)))).Returns(mock.Object);
+            ServiceProviderMock.Setup(m => m.GetService(typeof(TService))).Returns(mock.Object);
         }
 
         public Mock<IHubActivator<THub, IClientInvoker>> RegisterHub<THub>(THub hub = null) where THub : Hub<IClientInvoker>, new()
@@ -93,11 +91,10 @@ namespace MorseL.Shared.Tests
             var hubActivatorMock = new Mock<IHubActivator<THub, IClientInvoker>>();
             hubActivatorMock.Setup(m => m.Create()).Returns(hub ?? new THub());
 
-            _hubActivatorProviderMock.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(THub))))
-                                    .Returns(hubActivatorMock);
+            _hubActivatorProviderMock.Setup(m => m.GetService(typeof(THub))).Returns(hubActivatorMock);
 
-            ServiceProviderMock.Setup(m => m.GetService(It.Is<Type>(t => t == typeof(IHubActivator<THub, IClientInvoker>))))
-                        .Returns(hubActivatorMock.Object);
+            ServiceProviderMock.Setup(m => m.GetService(typeof(IHubActivator<THub, IClientInvoker>)))
+                .Returns(hubActivatorMock.Object);
 
             return hubActivatorMock;
         }

--- a/test/MorseL.Tests/HubMethodDiscovererTests.cs
+++ b/test/MorseL.Tests/HubMethodDiscovererTests.cs
@@ -46,7 +46,7 @@ namespace MorseL.Tests
             var discoverer = new HubMethodDiscoverer<AccessibilityHub, IClientInvoker>(
                 Mocker.LoggerFactoryMock.Object);
             Assert.Contains(discoverer._methods, m => m.Key == "PublicMethod");
-            Assert.Equal(discoverer._methods.Count, 1);
+            Assert.Equal(1, discoverer._methods.Count);
         }
 
         [Fact]
@@ -55,7 +55,7 @@ namespace MorseL.Tests
             var discoverer = new HubMethodDiscoverer<AccessibilityHub, IClientInvoker>(
                 Mocker.LoggerFactoryMock.Object);
             Assert.DoesNotContain(discoverer._methods, m => m.Key == "ProtectedMethod");
-            Assert.Equal(discoverer._methods.Count, 1);
+            Assert.Equal(1, discoverer._methods.Count);
         }
 
         [Fact]
@@ -64,7 +64,7 @@ namespace MorseL.Tests
             var discoverer = new HubMethodDiscoverer<AccessibilityHub, IClientInvoker>(
                 Mocker.LoggerFactoryMock.Object);
             Assert.DoesNotContain(discoverer._methods, m => m.Key == "PrivateMethod");
-            Assert.Equal(discoverer._methods.Count, 1);
+            Assert.Equal(1, discoverer._methods.Count);
         }
 
         [Fact]
@@ -73,7 +73,7 @@ namespace MorseL.Tests
             var discoverer = new HubMethodDiscoverer<AccessibilityHub, IClientInvoker>(
                 Mocker.LoggerFactoryMock.Object);
             Assert.DoesNotContain(discoverer._methods, m => m.Key == "InternalMethod");
-            Assert.Equal(discoverer._methods.Count, 1);
+            Assert.Equal(1, discoverer._methods.Count);
         }
 
         public class BaseHub : Hub<IClientInvoker>
@@ -92,7 +92,7 @@ namespace MorseL.Tests
             var discoverer = new HubMethodDiscoverer<SubclassHub, IClientInvoker>(
                 Mocker.LoggerFactoryMock.Object);
             Assert.Contains(discoverer._methods, m => m.Key == "SubclassMethod");
-            Assert.Equal(discoverer._methods.Count, 2);
+            Assert.Equal(2, discoverer._methods.Count);
         }
 
         [Fact]
@@ -101,7 +101,7 @@ namespace MorseL.Tests
             var discoverer = new HubMethodDiscoverer<SubclassHub, IClientInvoker>(
                 Mocker.LoggerFactoryMock.Object);
             Assert.Contains(discoverer._methods, m => m.Key == "BaseMethod");
-            Assert.Equal(discoverer._methods.Count, 2);
+            Assert.Equal(2, discoverer._methods.Count);
         }
     }
 }

--- a/test/MorseL.Tests/HubWebSocketHandlerTests.cs
+++ b/test/MorseL.Tests/HubWebSocketHandlerTests.cs
@@ -93,7 +93,7 @@ namespace MorseL.Tests
 
             await sut.OnDisconnectedAsync(connection, null);
 
-            Mocker.BackplaneMock.Verify(m => m.OnClientDisconnectedAsync(It.Is<string>(v => v == connectionId)), Times.Once);
+            Mocker.BackplaneMock.Verify(m => m.OnClientDisconnectedAsync(connectionId), Times.Once);
         }
 
         [Fact]
@@ -125,7 +125,7 @@ namespace MorseL.Tests
                 await sut.OnDisconnectedAsync(connection, null);
             });
 
-            Mocker.BackplaneMock.Verify(m => m.OnClientDisconnectedAsync(It.Is<string>(v => v == connectionId)), Times.Once);
+            Mocker.BackplaneMock.Verify(m => m.OnClientDisconnectedAsync(connectionId), Times.Once);
         }
     }
 }


### PR DESCRIPTION
Also fixes a cancellation related bug introduced in the recent
connection leak fix. The problem is that the middleware is created once
but invoke is called many times meaning that there cannot be a shared
CancellationTokenSource.

The fix removes the shared CTS and uses a local one within Invoke again
but does ensure that the CTS is disposed of in the recently added
finally block.