### PR TITLE
Run Redis automated tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -257,3 +257,6 @@ src/MorseL.Client.TS/app/build/
 
 *.map
 *.min.js
+
+nohup.out
+*.rdb

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,9 +10,13 @@ jobs:
   - script: dotnet build
     displayName: 'Build'
 
+  - script: docker run -d --name test-redis --rm -p 6379:6379 redis
+    displayName: 'Start Redis docker container for tests'
+
   - script: |
       dotnet test test/MorseL.Client.Tests --logger trx
       dotnet test test/MorseL.Client.WebSockets.Tests --logger trx
+      dotnet test test/MorseL.Scaleout.Redis.Tests --logger trx
       dotnet test test/MorseL.Scaleout.Tests --logger trx
       dotnet test test/MorseL.Sockets.Tests --logger trx
       dotnet test test/MorseL.Tests --logger trx
@@ -22,6 +26,9 @@ jobs:
     inputs:
       testRunner: VSTest
       testResultsFiles: '**/*.trx'
+
+  - script: docker container kill test-redis
+    displayName: 'Cleanup Redis docker container'
 
 - job: Windows
   pool:
@@ -35,8 +42,14 @@ jobs:
     displayName: 'Build'
 
   - script: |
+      choco install -y redis-64
+      start "redis" redis-server
+    displayName: 'Install and run Redis for tests'
+
+  - script: |
       dotnet test test/MorseL.Client.Tests --logger trx
       dotnet test test/MorseL.Client.WebSockets.Tests --logger trx
+      dotnet test test/MorseL.Scaleout.Redis.Tests --logger trx
       dotnet test test/MorseL.Scaleout.Tests --logger trx
       dotnet test test/MorseL.Sockets.Tests --logger trx
       dotnet test test/MorseL.Tests --logger trx
@@ -46,6 +59,11 @@ jobs:
     inputs:
       testRunner: VSTest
       testResultsFiles: '**/*.trx'
+
+  - script: |
+      taskkill /IM redis-server.exe
+      choco uninstall redis-64
+    displayName: 'Cleanup Redis'
 
 - job: macOS
   pool:
@@ -59,8 +77,14 @@ jobs:
     displayName: 'Build'
 
   - script: |
+      brew install redis
+      brew services start redis
+    displayName: 'Install and run Redis for tests'
+
+  - script: |
       dotnet test test/MorseL.Client.Tests --logger trx
       dotnet test test/MorseL.Client.WebSockets.Tests --logger trx
+      dotnet test test/MorseL.Scaleout.Redis.Tests --logger trx
       dotnet test test/MorseL.Scaleout.Tests --logger trx
       dotnet test test/MorseL.Sockets.Tests --logger trx
       dotnet test test/MorseL.Tests --logger trx
@@ -70,3 +94,8 @@ jobs:
     inputs:
       testRunner: VSTest
       testResultsFiles: '**/*.trx'
+
+  - script: |
+      brew services stop redis
+      brew uninstall redis
+    displayName: 'Cleanup Redis'


### PR DESCRIPTION
I managed to find a way to get Redis installed and running on all platforms. Biggest thing to note is that macOS and Linux both use 5.0+ but Windows only has 3.x available. We can't use the Redis Docker on the Windows hosted agent as it uses Linux base and the Windows Docker, it appears, is configured for Windows Docker images (and the only one I could find was _5 gigabytes_ in size...which seems not ideal). Something to consider for the future.