### PR TITLE
Ignoring SocketExceptions when closing socket.

### DIFF
--- a/src/MorseL.Client/Connection.cs
+++ b/src/MorseL.Client/Connection.cs
@@ -20,6 +20,7 @@ using MorseL.Diagnostics;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Nito.AsyncEx.Synchronous;
+using System.Net.Sockets;
 
 [assembly: InternalsVisibleTo("MorseL.Scaleout.Redis.Tests")]
 [assembly: InternalsVisibleTo("MorseL.Tests")]
@@ -485,13 +486,27 @@ namespace MorseL.Client
             if (_isDisposed) throw new MorseLException("This connection has already been disposed.");
             _isDisposed = true;
 
+            Exception exception = null;
+
             // These states were determined based on error messages thrown when sending
             // CloseAsync in a bad state ¯\_(ツ)_/¯
             if (_clientWebSocket.State == WebSocketState.Open
                 || _clientWebSocket.State == WebSocketState.CloseReceived
                 || _clientWebSocket.State == WebSocketState.CloseSent)
             {
-                await _clientWebSocket.CloseAsync(WebSocketCloseStatus.Empty, null, ct).ConfigureAwait(false);
+                try
+                {
+                    await _clientWebSocket.CloseAsync(WebSocketCloseStatus.Empty, null, ct).ConfigureAwait(false);
+                }
+                catch (IOException ex) when (ex.InnerException is SocketException)
+                {
+                    // Ignore SocketExceptions intentionally when closing a socket. The main reason for this
+                    // is issues encountered when losing network connection. Closing a socket after losing
+                    // network connection results in a "network subsystem is down" exception. It tries to
+                    // send a close message but cannot because there is no connection anymore.
+                    exception = ex;
+                    _logger.LogWarning(new EventId(), ex, "Observed SocketException - likely OK");
+                }
             }
 
             _clientWebSocket.Dispose();
@@ -502,7 +517,7 @@ namespace MorseL.Client
             }
 
             // Fire the closed event if necessary
-            FireClosed();
+            FireClosed(exception);
         }
 
         private void FireClosed(Exception e = null)


### PR DESCRIPTION
This will now ignore SocketExceptions when closing a socket. The main reason for this is issues encountered when losing network connection. Closing a socket after losing network connection results in a "network subsystem is down" exception. It tries to send a close message but cannot because there is no connection anymore.