### PR TITLE
Improve handling of abrupt connection drops

### DIFF
--- a/version.props
+++ b/version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.2.4</VersionPrefix>
+    <VersionPrefix>2.2.5</VersionPrefix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This adds handling for the `WebSocketException` thrown when networking is abruptly terminated. It is handled effectively the same as the general MorseL-specific `WebSocketClosedException` but will also invoke `Abort` to try to finalize terminating the socket as quickly as possible.